### PR TITLE
Update README for binary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can install Xylo using Cargo:
 ```sh
 cargo install xylo-lang
 ```
+This will install a binary named `xylo-lang`.
 
 ### Manual Build (Linux)
 
@@ -99,7 +100,7 @@ Write some Xylo code in a `.xylo` file e.g. `art.xylo`.
 Then, generate an image from that code:
 
 ```sh
-xylo generate art.xylo --width 800 --height 800
+xylo-lang generate art.xylo --width 800 --height 800
 ```
 
 If your code is valid, you should see an image output to `art.png`.


### PR DESCRIPTION
## Summary
- clarify that `cargo install` creates a `xylo-lang` binary
- update usage example to invoke `xylo-lang`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684171bc7e248331906ddb667f186f6f